### PR TITLE
Fix: Preserve DOCTYPE and html tag formatting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,25 +13,58 @@ export function activate(context: vscode.ExtensionContext) {
 			const srcHtml = document.getText();
 
 			const dom = new jsdom.JSDOM(srcHtml);
-			let outHtml = dom.serialize();
+			let outHtml;
 
-			let hasHtmlHead = false;
+			// This extension is intended for HTML that is the entire file, or a partial piece of HTML.
+			// The processing is divided accordingly.
+			// ファイル全体であるHTMLか、部分的なHTMLである事を想定した拡張機能です。
+			// それに応じて処理を分けています。
 			if (srcHtml.includes("<html")) {
-				hasHtmlHead = true;
-			}
 
-			// 元々がちゃんとした<html ...>といったようにフルのHTMLの予定のファイルならば...
-			if (hasHtmlHead) {
-				; // 何もしない
+				// In the case of entire HTML, we want to keep the original formatting of the <! DOCTYPE ...> and <html ...> parts.
+				// Therefore, we will replace only the <head> and <body> parts with the normalized ones.
+				// 全体HTMLの場合は、<!DOCTYPE ...>や<html ...>部分のオリジナルのフォーマットを維持したい。
+				// そのため、<head>と<body>の中身だけを正規化したものに差し替える
+				const normalizedHeadContent = dom.window.document.head.innerHTML;
+				const normalizedBodyContent = dom.window.document.body.innerHTML;
 
-			// そうではなく部分的なHTMLならば... あくまでも部分的にする
+				outHtml = srcHtml;
+
+				const headRegex = /<head.*?>([\s\S]*)<\/head>/is;
+				if (outHtml.match(headRegex)) {
+					outHtml = outHtml.replace(headRegex, (match) => {
+						const headTag = match.substring(0, match.indexOf('>') + 1);
+						return `${headTag}${normalizedHeadContent}</head>`;
+					});
+				} else {
+					// If there is no <head> tag, we do not do anything special.
+					// <head>タグがない場合は、特別な事はしない
+				}
+
+				const bodyRegex = /<body.*?>([\s\S]*)<\/body>/is;
+				if (outHtml.match(bodyRegex)) {
+					outHtml = outHtml.replace(bodyRegex, (match) => {
+						const bodyTag = match.substring(0, match.indexOf('>') + 1);
+						return `${bodyTag}${normalizedBodyContent}</body>`;
+					});
+				} else {
+					// If there is no <body> tag, we do not do anything special.
+					// <body>タグがない場合は、特別な事はしない
+				}
+
+
 			} else {
+				// In the case of partial HTML, we will only make it partial.
+				//部分的なHTMLならば... あくまでも部分的にする
 
+				let normalizedHtml = dom.serialize();
+				// JSDOM will add its own header and footer, so we will remove them.
 				// 勝手にJSDOMが追加したヘッダー部分やフッター部分を削除する
 				let head = "<html><head></head><body>";
-				outHtml = outHtml.replace(head, "");
+				normalizedHtml = normalizedHtml.replace(head, "");
 				let foot = "</body></html>";
-				outHtml = outHtml.replace(foot, "");
+				normalizedHtml = normalizedHtml.replace(foot, "");
+				outHtml = normalizedHtml;
 			}
 
 			if (compareIgnoringNewlines(srcHtml, outHtml)) {


### PR DESCRIPTION
The extension was previously re-serializing the entire HTML document using jsdom, which would overwrite the user's original formatting for the `<!DOCTYPE>`, `<html>`, `<head>`, and `<body>` tags.

This change modifies the behavior for full HTML documents. It now uses jsdom to normalize only the content inside the `<head>` and `<body>` tags. The extension then replaces only the inner content of these tags in the original source, preserving the formatting of the document's root structure and any attributes on the head and body tags.

The logic for handling partial HTML fragments remains unchanged.

これまで、この拡張機能は jsdom を使用して HTML ドキュメント全体を再シリアライズしていました。これにより、`<!DOCTYPE>`、`<html>`、`<head>`、`<body>` タグのユーザーが指定した元の書式が上書きされていました。

今回の変更により、HTML ドキュメント全体の動作が変更されます。jsdom を使用して `<head>` タグと `<body>` タグ内のコンテンツのみを正規化するようになりました。その後、拡張機能は元のソースにあるこれらのタグの内部コンテンツのみを置き換え、ドキュメントのルート構造と head タグおよび body タグの属性の書式は保持します。

部分的な HTML フラグメントの処理ロジックは変更されていません。